### PR TITLE
Update to gleam_otp 1.x and gleam_erlang 1.x

### DIFF
--- a/gleam.toml
+++ b/gleam.toml
@@ -10,9 +10,9 @@ internal_modules = [
 ]
 
 [dependencies]
-gleam_stdlib = ">= 0.34.0 and < 2.0.0"
-gleam_erlang = ">= 0.25.0 and < 1.0.0"
-gleam_otp = ">= 0.11.2 and < 1.0.0"
+gleam_stdlib = ">= 0.60.0 and < 2.0.0"
+gleam_erlang = ">= 1.0.0 and < 2.0.0"
+gleam_otp = ">= 1.0.0 and < 2.0.0"
 
 [dev-dependencies]
 gleeunit = ">= 1.0.0 and < 2.0.0"

--- a/manifest.toml
+++ b/manifest.toml
@@ -2,14 +2,14 @@
 # You typically do not need to edit this file
 
 packages = [
-  { name = "gleam_erlang", version = "0.25.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_erlang", source = "hex", outer_checksum = "054D571A7092D2A9727B3E5D183B7507DAB0DA41556EC9133606F09C15497373" },
-  { name = "gleam_otp", version = "0.11.2", build_tools = ["gleam"], requirements = ["gleam_erlang", "gleam_stdlib"], otp_app = "gleam_otp", source = "hex", outer_checksum = "517FFB679E44AD71D059F3EF6A17BA6EFC8CB94FA174D52E22FB6768CF684D78" },
-  { name = "gleam_stdlib", version = "0.40.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "86606B75A600BBD05E539EB59FABC6E307EEEA7B1E5865AFB6D980A93BCB2181" },
-  { name = "gleeunit", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "F7A7228925D3EE7D0813C922E062BFD6D7E9310F0BEE585D3A42F3307E3CFD13" },
+  { name = "gleam_erlang", version = "1.3.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_erlang", source = "hex", outer_checksum = "1124AD3AA21143E5AF0FC5CF3D9529F6DB8CA03E43A55711B60B6B7B3874375C" },
+  { name = "gleam_otp", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_erlang", "gleam_stdlib"], otp_app = "gleam_otp", source = "hex", outer_checksum = "BA6A294E295E428EC1562DC1C11EA7530DCB981E8359134BEABC8493B7B2258E" },
+  { name = "gleam_stdlib", version = "0.69.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "AAB0962BEBFAA67A2FBEE9EEE218B057756808DC9AF77430F5182C6115B3A315" },
+  { name = "gleeunit", version = "1.9.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "DA9553CE58B67924B3C631F96FE3370C49EB6D6DC6B384EC4862CC4AAA718F3C" },
 ]
 
 [requirements]
-gleam_erlang = { version = ">= 0.25.0 and < 1.0.0" }
-gleam_otp = { version = ">= 0.11.2 and < 1.0.0" }
-gleam_stdlib = { version = ">= 0.34.0 and < 2.0.0" }
+gleam_erlang = { version = ">= 1.0.0 and < 2.0.0" }
+gleam_otp = { version = ">= 1.0.0 and < 2.0.0" }
+gleam_stdlib = { version = ">= 0.60.0 and < 2.0.0" }
 gleeunit = { version = ">= 1.0.0 and < 2.0.0" }

--- a/src/glimit/rate_limiter.gleam
+++ b/src/glimit/rate_limiter.gleam
@@ -75,9 +75,9 @@ pub type Message {
   SetNow(now: Int)
 }
 
-fn handle_message(message: Message, state: State) -> actor.Next(Message, State) {
+fn handle_message(state: State, message: Message) -> actor.Next(State, Message) {
   case message {
-    Shutdown -> actor.Stop(process.Normal)
+    Shutdown -> actor.stop()
 
     Hit(client) -> {
       let state = refill_bucket(state)
@@ -116,8 +116,11 @@ pub fn new(
       last_update: None,
       now: None,
     )
-  actor.start(state, handle_message)
-  |> result.nil_error
+  actor.new(state)
+  |> actor.on_message(handle_message)
+  |> actor.start
+  |> result.map(fn(started) { started.data })
+  |> result.map_error(fn(_) { Nil })
 }
 
 /// Stop the rate limiter actor.
@@ -129,13 +132,13 @@ pub fn shutdown(rate_limiter: Subject(Message)) -> Nil {
 /// Mark a hit on the rate limiter actor.
 ///
 pub fn hit(rate_limiter: Subject(Message)) -> Result(Nil, Nil) {
-  actor.call(rate_limiter, Hit, 10)
+  actor.call(rate_limiter, waiting: 10, sending: Hit)
 }
 
 /// Returns True if the token bucket is full.
 ///
 pub fn has_full_bucket(rate_limiter: Subject(Message)) -> Bool {
-  actor.call(rate_limiter, HasFullBucket, 10)
+  actor.call(rate_limiter, waiting: 10, sending: HasFullBucket)
 }
 
 /// Set the current time for testing purposes.

--- a/src/glimit/registry.gleam
+++ b/src/glimit/registry.gleam
@@ -6,7 +6,6 @@ import gleam/erlang/process.{type Subject}
 import gleam/list
 import gleam/option.{type Option, None, Some}
 import gleam/otp/actor
-import gleam/otp/task
 import gleam/result
 import glimit/rate_limiter
 
@@ -63,9 +62,9 @@ fn handle_get_or_create(
 }
 
 fn handle_message(
-  message: Message(id),
   state: State(id),
-) -> actor.Next(Message(id), State(id)) {
+  message: Message(id),
+) -> actor.Next(State(id), Message(id)) {
   case message {
     GetOrCreate(identifier, client) -> {
       case handle_get_or_create(identifier, state) {
@@ -113,11 +112,14 @@ pub fn new(
       registry: dict.new(),
     )
   use registry <- result.try(
-    actor.start(state, handle_message)
-    |> result.nil_error,
+    actor.new(state)
+    |> actor.on_message(handle_message)
+    |> actor.start
+    |> result.map(fn(started) { started.data })
+    |> result.map_error(fn(_) { Nil }),
   )
 
-  task.async(fn() { sweep(registry, Some(10)) })
+  process.spawn(fn() { sweep(registry, Some(10)) })
 
   Ok(registry)
 }
@@ -128,7 +130,7 @@ pub fn get_or_create(
   registry: RateLimiterRegistryActor(id),
   identifier: id,
 ) -> Result(Subject(rate_limiter.Message), Nil) {
-  actor.call(registry, GetOrCreate(identifier, _), 10)
+  actor.call(registry, waiting: 10, sending: GetOrCreate(identifier, _))
 }
 
 /// Return a list of rate limiters.
@@ -136,7 +138,7 @@ pub fn get_or_create(
 pub fn get_all(
   registry: RateLimiterRegistryActor(id),
 ) -> List(#(id, Subject(rate_limiter.Message))) {
-  actor.call(registry, GetAll, 10)
+  actor.call(registry, waiting: 10, sending: GetAll)
 }
 
 /// Remove a rate limiter from the registry.
@@ -145,7 +147,7 @@ pub fn remove(
   registry: RateLimiterRegistryActor(id),
   identifier: id,
 ) -> Result(Nil, Nil) {
-  actor.call(registry, Remove(identifier, _), 10)
+  actor.call(registry, waiting: 10, sending: Remove(identifier, _))
   Ok(Nil)
 }
 


### PR DESCRIPTION
## Summary

- Update `gleam_otp` from `< 1.0.0` to `>= 1.0.0 and < 2.0.0` (resolves to 1.2.0)
- Update `gleam_erlang` from `< 1.0.0` to `>= 1.0.0 and < 2.0.0` (resolves to 1.3.0)
- Update `gleam_stdlib` minimum from `0.34.0` to `0.60.0` (required by gleam_otp 1.x)
- Migrate all actor code to the new builder API (`actor.new` / `actor.on_message` / `actor.start`)
- Replace removed `gleam/otp/task` module usage with `process.spawn`
- Replace removed `result.nil_error` with `result.map_error`

## Motivation

The `gleam_otp` and `gleam_erlang` packages both released 1.0 with significant API changes. The current version constraints (`< 1.0.0`) prevent users on recent Gleam/OTP versions from using glimit.

## API changes applied

| Old (gleam_otp 0.x) | New (gleam_otp 1.x) |
|---|---|
| `actor.start(state, handler)` | `actor.new(state) \|> actor.on_message(handler) \|> actor.start` |
| `fn(message, state) -> Next(Message, State)` | `fn(state, message) -> Next(State, Message)` |
| `actor.Stop(process.Normal)` | `actor.stop()` |
| `actor.call(subject, fn, timeout)` | `actor.call(subject, waiting: timeout, sending: fn)` |
| `task.async(fn)` | `process.spawn(fn)` |
| `result.nil_error` | `result.map_error(fn(_) { Nil })` |

## Test plan

- [x] `gleam build` compiles cleanly
- [x] `gleam test` — all 13 tests pass
- [x] `gleam format --check` — no formatting issues