### PR TITLE
fix: bump Gleam to 1.14.0 and OTP to 27 in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,8 +14,8 @@ jobs:
       - uses: actions/checkout@v4
       - uses: erlef/setup-beam@v1
         with:
-          otp-version: "26.0.2"
-          gleam-version: "1.4.1"
+          otp-version: "27"
+          gleam-version: "1.14.0"
           rebar3-version: "3"
           # elixir-version: "1.15.4"
       - run: gleam deps download


### PR DESCRIPTION
gleam_stdlib 0.69.0 (pulled in by gleam_otp 1.x) requires Gleam >= 1.14.0, causing the test job to fail with the previous Gleam 1.4.1.