### PR TITLE
fix: prevent actor leak when build() fails on late validation

### DIFF
--- a/src/glimit.gleam
+++ b/src/glimit.gleam
@@ -244,10 +244,6 @@ pub fn build(
     Some(burst_limit) -> burst_limit
     None -> per_second
   }
-  use rate_limiter_actor <- result.try(
-    rate_limiter.new(per_second, burst_limit)
-    |> result.map_error(fn(_) { "Failed to start rate limiter" }),
-  )
   use identifier <- result.try(case config.identifier {
     Some(identifier) -> Ok(identifier)
     None -> Error("`identifier` function is required")
@@ -256,6 +252,10 @@ pub fn build(
     Some(on_limit_exceeded) -> Ok(on_limit_exceeded)
     None -> Error("`on_limit_exceeded` function is required")
   })
+  use rate_limiter_actor <- result.try(
+    rate_limiter.new(per_second, burst_limit)
+    |> result.map_error(fn(_) { "Failed to start rate limiter" }),
+  )
 
   Ok(RateLimiter(
     rate_limiter_actor: rate_limiter_actor,


### PR DESCRIPTION
## Summary

- Reorder `build()` to validate all required fields (`identifier`, `on_limit_exceeded`) before starting the rate limiter actor
- Previously the actor was spawned first and leaked if a subsequent validation failed

## Test plan

- [x] All 49 existing tests pass
- [x] Verified happy path is unaffected by the reordering

Ref #13
