### PR TITLE
fix: protect actor from crashing user callbacks

### DIFF
--- a/src/glimit/rate_limiter.gleam
+++ b/src/glimit/rate_limiter.gleam
@@ -83,12 +83,12 @@ fn ensure_bucket(
   case dict.get(state.buckets, identifier) {
     Ok(b) -> Ok(#(b, state))
     Error(_) -> {
-      use max <- result.try(utils.rescue(fn() {
-        state.max_token_count(identifier)
-      }))
-      use rate <- result.try(utils.rescue(fn() {
-        state.token_rate(identifier)
-      }))
+      use max <- result.try(
+        utils.rescue(fn() { state.max_token_count(identifier) }),
+      )
+      use rate <- result.try(
+        utils.rescue(fn() { state.token_rate(identifier) }),
+      )
       case bucket.new(max, rate) {
         Ok(b) -> {
           let buckets = dict.insert(state.buckets, identifier, b)

--- a/src/glimit/rate_limiter.gleam
+++ b/src/glimit/rate_limiter.gleam
@@ -83,12 +83,13 @@ fn ensure_bucket(
   case dict.get(state.buckets, identifier) {
     Ok(b) -> Ok(#(b, state))
     Error(_) -> {
-      case
-        bucket.new(
-          state.max_token_count(identifier),
-          state.token_rate(identifier),
-        )
-      {
+      use max <- result.try(utils.rescue(fn() {
+        state.max_token_count(identifier)
+      }))
+      use rate <- result.try(utils.rescue(fn() {
+        state.token_rate(identifier)
+      }))
+      case bucket.new(max, rate) {
         Ok(b) -> {
           let buckets = dict.insert(state.buckets, identifier, b)
           Ok(#(b, State(..state, buckets: buckets)))

--- a/src/glimit/utils.gleam
+++ b/src/glimit/utils.gleam
@@ -13,6 +13,12 @@ pub fn now() -> Int {
   megaseconds * 1_000_000_000 + seconds * 1000 + microseconds / 1000
 }
 
+/// Wrap a zero-arity function so that a crash returns `Error(Nil)`
+/// instead of propagating.
+///
+@external(erlang, "glimit_ffi", "rescue")
+pub fn rescue(f: fn() -> a) -> Result(a, Nil)
+
 /// Like process.call but returns Result instead of panicking on timeout or
 /// callee death.
 ///

--- a/src/glimit_ffi.erl
+++ b/src/glimit_ffi.erl
@@ -1,0 +1,9 @@
+-module(glimit_ffi).
+-export([rescue/1]).
+
+rescue(Fun) ->
+    try
+        {ok, Fun()}
+    catch
+        _:_:_ -> {error, nil}
+    end.

--- a/test/glimit_rate_limiter_test.gleam
+++ b/test/glimit_rate_limiter_test.gleam
@@ -218,6 +218,50 @@ pub fn invalid_config_returns_unavailable_test() {
   rate_limiter.get_count(rl) |> should.equal(1)
 }
 
+pub fn crashing_callback_returns_unavailable_test() {
+  let assert Ok(rl) =
+    rate_limiter.new(
+      fn(id) {
+        case id {
+          "crash" -> panic as "boom"
+          _ -> 2
+        }
+      },
+      fn(id) {
+        case id {
+          "crash" -> panic as "boom"
+          _ -> 2
+        }
+      },
+    )
+
+  // Crashing callback should return Unavailable, not kill the actor
+  rate_limiter.hit(rl, "crash")
+  |> should.equal(Error(rate_limiter.Unavailable))
+
+  // Actor is still alive and serving other identifiers
+  rate_limiter.hit(rl, "good") |> should.be_ok
+}
+
+pub fn crashing_single_callback_returns_unavailable_test() {
+  // Only per_second crashes; burst_limit is fine
+  let assert Ok(rl) =
+    rate_limiter.new(
+      fn(id) {
+        case id {
+          "crash" -> panic as "boom"
+          _ -> 2
+        }
+      },
+      fn(_) { 2 },
+    )
+
+  rate_limiter.hit(rl, "crash")
+  |> should.equal(Error(rate_limiter.Unavailable))
+
+  rate_limiter.hit(rl, "good") |> should.be_ok
+}
+
 pub fn dead_rate_limiter_returns_unavailable_test() {
   let assert Ok(rl) = rate_limiter.new(fn(_) { 2 }, fn(_) { 2 })
 

--- a/test/glimit_utils_test.gleam
+++ b/test/glimit_utils_test.gleam
@@ -16,6 +16,16 @@ type TimeoutMsg {
   Ping(reply_with: Subject(Nil))
 }
 
+pub fn rescue_returns_ok_on_success_test() {
+  utils.rescue(fn() { 42 })
+  |> should.equal(Ok(42))
+}
+
+pub fn rescue_returns_error_on_crash_test() {
+  utils.rescue(fn() { panic as "boom" })
+  |> should.equal(Error(Nil))
+}
+
 pub fn safe_call_timeout_test() {
   // Start an actor that ignores all messages (never replies)
   let assert Ok(started) =


### PR DESCRIPTION
## Summary

- Adds Erlang FFI `rescue/1` that wraps a zero-arity function in try/catch, returning `{ok, Value}` or `{error, nil}`
- Wraps user-provided `max_token_count` and `token_rate` callbacks in `rescue` inside `ensure_bucket`, so a panicking callback returns `Unavailable` instead of killing the actor
- Adds tests for crashing callbacks (both and single), plus direct unit tests for the `rescue` utility

Ref #13

## Test plan

- [x] `gleam test` — all 53 tests pass (49 existing + 4 new)
- [x] Verify crashing callback returns `Unavailable` and actor stays alive
- [x] Verify single callback crash is handled correctly
- [x] Verify `rescue` returns `Ok` on success and `Error(Nil)` on crash