### PR TITLE
fix: use monotonic time instead of wall-clock time

### DIFF
--- a/src/glimit/bucket.gleam
+++ b/src/glimit/bucket.gleam
@@ -18,7 +18,7 @@ pub type BucketState {
     /// The number of tokens available.
     ///
     token_count: Float,
-    /// Epoch timestamp (milliseconds) of the last time the bucket was updated.
+    /// Monotonic timestamp (milliseconds) of the last time the bucket was updated.
     ///
     last_update: Option(Int),
   )

--- a/src/glimit/rate_limiter.gleam
+++ b/src/glimit/rate_limiter.gleam
@@ -242,7 +242,7 @@ pub fn sweep(rate_limiter: RateLimiterActor(id)) -> Result(Nil, Nil) {
 }
 
 /// Set the current time for testing purposes.
-/// The `now` value must be in epoch milliseconds.
+/// The `now` value is in milliseconds.
 ///
 pub fn set_now(rate_limiter: RateLimiterActor(id), now: Int) -> Nil {
   let _ = utils.safe_call(rate_limiter, SetNow(now, _), call_timeout)

--- a/src/glimit/utils.gleam
+++ b/src/glimit/utils.gleam
@@ -4,13 +4,14 @@
 import gleam/erlang/process.{type Subject}
 import gleam/result
 
-@external(erlang, "os", "timestamp")
-fn now_erlang() -> #(Int, Int, Int)
+@external(erlang, "glimit_ffi", "monotonic_now_ms")
+fn monotonic_now_ms() -> Int
 
-/// Get the current time in epoch milliseconds.
+/// Get the current monotonic time in milliseconds.
+/// Monotonic time is immune to wall-clock adjustments (NTP, manual changes)
+/// and is suitable for measuring elapsed intervals.
 pub fn now() -> Int {
-  let #(megaseconds, seconds, microseconds) = now_erlang()
-  megaseconds * 1_000_000_000 + seconds * 1000 + microseconds / 1000
+  monotonic_now_ms()
 }
 
 /// Like process.call but returns Result instead of panicking on timeout or

--- a/src/glimit_ffi.erl
+++ b/src/glimit_ffi.erl
@@ -1,0 +1,5 @@
+-module(glimit_ffi).
+-export([monotonic_now_ms/0]).
+
+monotonic_now_ms() ->
+    erlang:monotonic_time(millisecond).

--- a/test/glimit_utils_test.gleam
+++ b/test/glimit_utils_test.gleam
@@ -3,10 +3,8 @@ import gleam/otp/actor
 import gleeunit/should
 import glimit/utils
 
-pub fn now_returns_milliseconds_test() {
+pub fn now_is_monotonic_test() {
   let t1 = utils.now()
-  // Should be a reasonable epoch milliseconds value (after 2024-01-01)
-  let assert True = t1 > 1_704_067_200_000
   // Two calls should be monotonically non-decreasing
   let t2 = utils.now()
   let assert True = t2 >= t1


### PR DESCRIPTION
## Summary

- Replace os:timestamp() with erlang:monotonic_time(millisecond) via Erlang FFI to prevent NTP clock jumps from bypassing rate limits
- Forward clock jumps could cause buckets to refill instantly; monotonic time is immune to clock adjustments
- Also eliminates backward clock jump issue where buckets would freeze until the clock caught up (issue #13 item 7)

Ref #13

## Test plan

- [x] gleam test — all 49 tests pass
- [x] Verify now() returns monotonically non-decreasing values
- [x] Verify set_now test mechanism still works (tests use explicit time values, unaffected by time source change)
