### PR TITLE
fix: add idle eviction, fix docs, and add tests

### DIFF
--- a/examples/wisp/src/app.gleam
+++ b/examples/wisp/src/app.gleam
@@ -13,6 +13,9 @@ pub fn main() {
     glimit.new()
     |> glimit.per_second(1)
     |> glimit.burst_limit(5)
+    // NOTE: X-Forwarded-For is trivially spoofable by clients. Only trust
+    // this header when running behind a trusted reverse proxy. In production,
+    // extract only the first or last IP depending on your proxy configuration.
     |> glimit.identifier(fn(req: Request) {
       req
       |> request.get_header("X-Forwarded-For")

--- a/src/glimit.gleam
+++ b/src/glimit.gleam
@@ -3,7 +3,8 @@
 ////
 //// A single rate limiter actor stores all token bucket state. Each hit is a single
 //// message to the rate limiter, which performs the Token Bucket calculation inline.
-//// A periodic sweep removes idle (full) buckets to reduce memory usage. The
+//// A periodic sweep removes full or idle (>60s without activity) buckets to
+//// reduce memory usage. The
 //// rate limiter fails open — if the rate limiter actor is unavailable, requests are
 //// allowed through.
 ////

--- a/src/glimit.gleam
+++ b/src/glimit.gleam
@@ -119,6 +119,11 @@ pub fn per_second(
 
 /// Set the rate limit per second, based on the identifier.
 ///
+/// Note: this function is evaluated once when a bucket is first created for an
+/// identifier. If the function returns a different value later, existing buckets
+/// are not affected until they are swept (due to idleness or being full) and
+/// re-created on the next hit.
+///
 /// # Example
 ///
 /// ```gleam
@@ -142,7 +147,8 @@ pub fn per_second_fn(
 /// Set the maximum number of available tokens.
 ///
 /// The maximum number of available tokens is the maximum number of requests that can be
-/// made in a single second. The default value is the same as the rate limit per second.
+/// made in a single burst when the bucket is full. The default value is the same as the
+/// rate limit per second.
 ///
 /// # Example
 ///
@@ -163,6 +169,11 @@ pub fn burst_limit(
 }
 
 /// Set the maximum number of available tokens, based on the identifier.
+///
+/// Note: this function is evaluated once when a bucket is first created for an
+/// identifier. If the function returns a different value later, existing buckets
+/// are not affected until they are swept (due to idleness or being full) and
+/// re-created on the next hit.
 ///
 /// # Example
 ///

--- a/src/glimit/rate_limiter.gleam
+++ b/src/glimit/rate_limiter.gleam
@@ -112,6 +112,7 @@ fn do_sweep(state: State(id)) -> State(id) {
 
 fn is_idle(state: BucketState, now: Int) -> Bool {
   case state.last_update {
+    // A bucket with no last_update was never hit; treat as idle (defensive).
     None -> True
     Some(last_update) -> now - last_update > max_idle_ms
   }
@@ -244,7 +245,7 @@ pub fn remove(
   utils.safe_call(rate_limiter, Remove(identifier, _), call_timeout)
 }
 
-/// Remove full buckets from the rate limiter synchronously.
+/// Remove full or idle buckets from the rate limiter synchronously.
 /// Intended for testing — production uses the periodic `Sweep` timer.
 ///
 pub fn sweep(rate_limiter: RateLimiterActor(id)) -> Result(Nil, Nil) {

--- a/src/glimit/rate_limiter.gleam
+++ b/src/glimit/rate_limiter.gleam
@@ -11,6 +11,8 @@ import glimit/utils
 
 const call_timeout = 1000
 
+const max_idle_ms = 60_000
+
 /// Error type returned by `hit`.
 ///
 pub type HitError {
@@ -104,8 +106,17 @@ fn do_sweep(state: State(id)) -> State(id) {
   let now = get_now(state)
   let buckets =
     state.buckets
-    |> dict.filter(fn(_id, b) { !bucket.is_full(b, now) })
+    |> dict.filter(fn(_id, b) {
+      !bucket.is_full(b, now) && !is_idle(b, now)
+    })
   State(..state, buckets: buckets)
+}
+
+fn is_idle(state: BucketState, now: Int) -> Bool {
+  case state.last_update {
+    None -> True
+    Some(last_update) -> now - last_update > max_idle_ms
+  }
 }
 
 fn schedule_sweep(state: State(id)) -> Nil {

--- a/src/glimit/rate_limiter.gleam
+++ b/src/glimit/rate_limiter.gleam
@@ -106,9 +106,7 @@ fn do_sweep(state: State(id)) -> State(id) {
   let now = get_now(state)
   let buckets =
     state.buckets
-    |> dict.filter(fn(_id, b) {
-      !bucket.is_full(b, now) && !is_idle(b, now)
-    })
+    |> dict.filter(fn(_id, b) { !bucket.is_full(b, now) && !is_idle(b, now) })
   State(..state, buckets: buckets)
 }
 

--- a/test/glimit_rate_limiter_test.gleam
+++ b/test/glimit_rate_limiter_test.gleam
@@ -1,4 +1,5 @@
 import gleam/erlang/process
+import gleam/list
 import gleeunit/should
 import glimit/rate_limiter
 
@@ -260,6 +261,49 @@ pub fn crashing_single_callback_returns_unavailable_test() {
   |> should.equal(Error(rate_limiter.Unavailable))
 
   rate_limiter.hit(rl, "good") |> should.be_ok
+}
+
+pub fn sweep_idle_bucket_test() {
+  // burst_limit=100, per_second=1: after exhausting all tokens, the bucket
+  // needs 100 seconds to refill. At t=61s it has 61 tokens (not full), but
+  // has been idle for >60s and should be swept.
+  let assert Ok(rl) = rate_limiter.new(fn(_) { 1 }, fn(_) { 100 })
+  rate_limiter.set_now(rl, 0)
+
+  // Exhaust all 100 tokens
+  list.repeat(Nil, 100)
+  |> list.each(fn(_) {
+    let _ = rate_limiter.hit(rl, "a")
+    Nil
+  })
+
+  rate_limiter.get_count(rl) |> should.equal(1)
+
+  // At t=61_000: tokens = 0 + 61 = 61 < 100, not full
+  // But idle for 61s > 60s threshold — should be swept
+  rate_limiter.set_now(rl, 61_000)
+  let assert Ok(Nil) = rate_limiter.sweep(rl)
+
+  rate_limiter.get_count(rl) |> should.equal(0)
+}
+
+pub fn sweep_idle_preserves_recent_bucket_test() {
+  // Same setup, but sweep before the idle threshold — bucket should be kept
+  let assert Ok(rl) = rate_limiter.new(fn(_) { 1 }, fn(_) { 100 })
+  rate_limiter.set_now(rl, 0)
+
+  list.repeat(Nil, 100)
+  |> list.each(fn(_) {
+    let _ = rate_limiter.hit(rl, "a")
+    Nil
+  })
+
+  // At t=59_000: tokens = 59 < 100 (not full), idle for 59s < 60s (not idle)
+  rate_limiter.set_now(rl, 59_000)
+  let assert Ok(Nil) = rate_limiter.sweep(rl)
+
+  // Should be kept — not full and not idle
+  rate_limiter.get_count(rl) |> should.equal(1)
 }
 
 pub fn dead_rate_limiter_returns_unavailable_test() {

--- a/test/glimit_rate_limiter_test.gleam
+++ b/test/glimit_rate_limiter_test.gleam
@@ -287,6 +287,24 @@ pub fn sweep_idle_bucket_test() {
   rate_limiter.get_count(rl) |> should.equal(0)
 }
 
+pub fn sweep_idle_exact_boundary_test() {
+  // At exactly 60s, idle duration is NOT > 60s, so bucket should be kept
+  let assert Ok(rl) = rate_limiter.new(fn(_) { 1 }, fn(_) { 100 })
+  rate_limiter.set_now(rl, 0)
+
+  list.repeat(Nil, 100)
+  |> list.each(fn(_) {
+    let _ = rate_limiter.hit(rl, "a")
+    Nil
+  })
+
+  rate_limiter.set_now(rl, 60_000)
+  let assert Ok(Nil) = rate_limiter.sweep(rl)
+
+  // 60_000 - 0 = 60_000, which is NOT > 60_000 — kept
+  rate_limiter.get_count(rl) |> should.equal(1)
+}
+
 pub fn sweep_idle_preserves_recent_bucket_test() {
   // Same setup, but sweep before the idle threshold — bucket should be kept
   let assert Ok(rl) = rate_limiter.new(fn(_) { 1 }, fn(_) { 100 })

--- a/test/glimit_test.gleam
+++ b/test/glimit_test.gleam
@@ -583,6 +583,41 @@ pub fn dead_rate_limiter_fails_open_test() {
   func("user") |> should.equal("OK")
 }
 
+pub fn per_second_zero_fails_open_test() {
+  // per_second(0) is invalid — bucket creation fails at hit time,
+  // so the limiter fails open and the original function is called.
+  let assert Ok(limiter) =
+    glimit.new()
+    |> glimit.per_second(0)
+    |> glimit.identifier(fn(_) { "id" })
+    |> glimit.on_limit_exceeded(fn(_) { "Stop!" })
+    |> glimit.build
+
+  let func =
+    fn(_) { "OK" }
+    |> glimit.apply_built(limiter)
+
+  // Invalid config causes Unavailable → fails open
+  func(Nil) |> should.equal("OK")
+  func(Nil) |> should.equal("OK")
+}
+
+pub fn per_second_negative_fails_open_test() {
+  let assert Ok(limiter) =
+    glimit.new()
+    |> glimit.per_second(-1)
+    |> glimit.identifier(fn(_) { "id" })
+    |> glimit.on_limit_exceeded(fn(_) { "Stop!" })
+    |> glimit.build
+
+  let func =
+    fn(_) { "OK" }
+    |> glimit.apply_built(limiter)
+
+  func(Nil) |> should.equal("OK")
+  func(Nil) |> should.equal("OK")
+}
+
 fn ignore(_value: a) -> Nil {
   Nil
 }


### PR DESCRIPTION
## Summary

- **Idle eviction in sweep**: Buckets idle for >60s are now removed even if not full, preventing unbounded memory growth from high-cardinality identifier spaces (e.g. spoofed IPs)
- **Wisp example security warning**: Added comment that `X-Forwarded-For` is spoofable and should only be trusted behind a reverse proxy
- **Fix `burst_limit` doc comment**: Changed "in a single second" to "in a single burst when the bucket is full"
- **Document dynamic config behavior**: `per_second_fn`/`burst_limit_fn` are evaluated once at bucket creation, not on every hit
- **New tests**: `per_second(0)` fail-open behavior, idle eviction sweep, and idle preservation for recent buckets

## Test plan

- [x] All 57 tests pass (`gleam test`)
- [x] Verify idle eviction does not break existing sweep behavior
- [x] Verify fail-open behavior with invalid `per_second` values