### PR TITLE
chore: add Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,36 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "chore"
+
+  - package-ecosystem: "hex"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "chore"
+
+  - package-ecosystem: "hex"
+    directory: "/examples/mist"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "chore"
+
+  - package-ecosystem: "hex"
+    directory: "/examples/lustre"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "chore"
+
+  - package-ecosystem: "hex"
+    directory: "/examples/wisp"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "chore"


### PR DESCRIPTION
## Summary
- Add Dependabot configuration for automated dependency updates
- Configure weekly updates for GitHub Actions and Hex (Gleam) ecosystems
- Include example subdirectories (`examples/mist`, `examples/lustre`, `examples/wisp`)
- Use `chore` commit message prefix to match repository conventions

## Verification
- After merge, check Dependabot settings page for any YAML errors
- Dependabot should create update PRs on its next weekly run