### PR TITLE
chore: add automated Gleam dependency update workflow

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "chore"

--- a/.github/workflows/deps-update.yml
+++ b/.github/workflows/deps-update.yml
@@ -1,0 +1,59 @@
+name: deps-update
+
+on:
+  schedule:
+    - cron: "0 6 * * 1" # Every Monday at 06:00 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  update-deps:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: erlef/setup-beam@v1
+        with:
+          otp-version: "27"
+          gleam-version: "1.14.0"
+          rebar3-version: "3"
+
+      - name: Check for outdated deps
+        id: check
+        run: |
+          OUTPUT=$(gleam deps outdated 2>&1) || true
+          echo "$OUTPUT"
+          if echo "$OUTPUT" | grep -q "All dependencies are up to date"; then
+            echo "outdated=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "outdated=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Update root deps
+        if: steps.check.outputs.outdated == 'true'
+        run: gleam update
+
+      - name: Update example deps
+        if: steps.check.outputs.outdated == 'true'
+        run: |
+          for dir in examples/lustre examples/mist examples/wisp; do
+            echo "Updating $dir"
+            cd "$dir"
+            gleam update
+            cd "$GITHUB_WORKSPACE"
+          done
+
+      - name: Create PR
+        if: steps.check.outputs.outdated == 'true'
+        uses: peter-evans/create-pull-request@v7
+        with:
+          branch: chore/gleam-deps-update
+          title: "chore: update Gleam dependencies"
+          body: |
+            Automated Gleam dependency update.
+
+            Run `gleam deps outdated` locally to review changes.
+          commit-message: "chore: update Gleam dependencies"
+          delete-branch: true


### PR DESCRIPTION
## Summary
- Add Dependabot config for weekly GitHub Actions updates
- Add scheduled workflow that checks for outdated Gleam deps and opens a PR with updates (root + example dirs)
- Supports manual trigger via `workflow_dispatch`