### PR TITLE
refactor: extract redis store adapter into separate module

### DIFF
--- a/examples/redis/src/app.gleam
+++ b/examples/redis/src/app.gleam
@@ -1,91 +1,13 @@
 import gleam/bytes_tree
-import gleam/dict
 import gleam/erlang/process
 import gleam/http/request.{type Request}
 import gleam/http/response.{type Response}
-import gleam/list
-import gleam/option.{None, Some}
 import gleam/result
 import gleam/string
 import glimit
-import glimit/bucket
 import mist.{type Connection, type ResponseData}
+import redis_store
 import valkyrie
-import valkyrie/resp
-
-const redis_timeout = 1000
-
-fn resp_to_string(value: resp.Value) -> Result(String, Nil) {
-  case value {
-    resp.SimpleString(s) | resp.BulkString(s) -> Ok(s)
-    _ -> Error(Nil)
-  }
-}
-
-fn redis_store(conn: valkyrie.Connection) -> glimit.Store {
-  let lock = fn(key) {
-    let opts =
-      valkyrie.SetOptions(
-        existence_condition: Some(valkyrie.IfNotExists),
-        return_old: False,
-        expiry_option: Some(valkyrie.ExpirySeconds(5)),
-      )
-    case valkyrie.set(conn, key <> ":lock", "1", Some(opts), redis_timeout) {
-      Ok(_) -> Ok(Nil)
-      Error(_) -> Error(Nil)
-    }
-  }
-
-  let get = fn(key) {
-    case valkyrie.hgetall(conn, key, redis_timeout) {
-      Ok(fields) -> {
-        let pairs =
-          dict.to_list(fields)
-          |> list.filter_map(fn(p) {
-            use k <- result.try(resp_to_string(p.0))
-            use v <- result.try(resp_to_string(p.1))
-            Ok(#(k, v))
-          })
-        case bucket.from_pairs(pairs) {
-          Ok(state) -> Ok(Some(state))
-          _ -> Ok(None)
-        }
-      }
-      Error(_) -> Error(Nil)
-    }
-  }
-
-  let unlock = fn(key) {
-    let _ = valkyrie.del(conn, [key <> ":lock"], redis_timeout)
-    Ok(Nil)
-  }
-
-  bucket.Store(
-    lock_and_get: fn(key) {
-      use _ <- result.try(lock(key))
-      case get(key) {
-        Ok(result) -> Ok(result)
-        Error(_) -> {
-          let _ = unlock(key)
-          Error(Nil)
-        }
-      }
-    },
-    set_and_unlock: fn(key, state, ttl) {
-      let fields = bucket.to_pairs(state) |> dict.from_list
-      let result = case valkyrie.hset(conn, key, fields, redis_timeout) {
-        Ok(_) -> {
-          let _ = valkyrie.expire(conn, key, ttl, None, redis_timeout)
-          Ok(Nil)
-        }
-        Error(_) -> Error(Nil)
-      }
-      let _ = unlock(key)
-      result
-    },
-    unlock: unlock,
-  )
-}
 
 fn get_ip(req: Request(Connection)) -> String {
   req.body
@@ -97,13 +19,13 @@ fn get_ip(req: Request(Connection)) -> String {
 pub fn main() {
   let assert Ok(conn) =
     valkyrie.default_config()
-    |> valkyrie.create_connection(redis_timeout)
+    |> valkyrie.create_connection(redis_store.default_timeout)
 
   let limiter =
     glimit.new()
     |> glimit.per_second(1)
     |> glimit.burst_limit(5)
-    |> glimit.store(redis_store(conn))
+    |> glimit.store(redis_store.new(conn))
     |> glimit.identifier(get_ip)
     |> glimit.on_limit_exceeded(fn(_) {
       response.new(429)

--- a/examples/redis/src/redis_store.gleam
+++ b/examples/redis/src/redis_store.gleam
@@ -1,0 +1,108 @@
+import gleam/dict
+import gleam/list
+import gleam/option.{type Option, None, Some}
+import gleam/result
+import glimit/bucket
+import valkyrie
+import valkyrie/resp
+
+pub const default_timeout = 1000
+
+fn lock_key(key: String) -> String {
+  key <> ":lock"
+}
+
+fn resp_to_string(value: resp.Value) -> Result(String, Nil) {
+  case value {
+    resp.SimpleString(s) | resp.BulkString(s) -> Ok(s)
+    _ -> Error(Nil)
+  }
+}
+
+fn lock(conn: valkyrie.Connection, key: String) -> Result(Nil, Nil) {
+  let opts =
+    valkyrie.SetOptions(
+      existence_condition: Some(valkyrie.IfNotExists),
+      return_old: False,
+      expiry_option: Some(valkyrie.ExpirySeconds(5)),
+    )
+  case valkyrie.set(conn, lock_key(key), "1", Some(opts), default_timeout) {
+    Ok(_) -> Ok(Nil)
+    Error(_) -> Error(Nil)
+  }
+}
+
+fn get(
+  conn: valkyrie.Connection,
+  key: String,
+) -> Result(Option(bucket.BucketState), Nil) {
+  case valkyrie.hgetall(conn, key, default_timeout) {
+    Ok(fields) -> {
+      let pairs =
+        dict.to_list(fields)
+        |> list.filter_map(fn(p) {
+          use k <- result.try(resp_to_string(p.0))
+          use v <- result.try(resp_to_string(p.1))
+          Ok(#(k, v))
+        })
+      case bucket.from_pairs(pairs) {
+        Ok(state) -> Ok(Some(state))
+        _ -> Ok(None)
+      }
+    }
+    Error(_) -> Error(Nil)
+  }
+}
+
+fn unlock(conn: valkyrie.Connection, key: String) -> Result(Nil, Nil) {
+  let _ = valkyrie.del(conn, [lock_key(key)], default_timeout)
+  Ok(Nil)
+}
+
+fn lock_and_get(
+  conn: valkyrie.Connection,
+  key: String,
+) -> Result(Option(bucket.BucketState), Nil) {
+  use _ <- result.try(lock(conn, key))
+  case get(conn, key) {
+    Ok(result) -> Ok(result)
+    Error(_) -> {
+      let _ = unlock(conn, key)
+      Error(Nil)
+    }
+  }
+}
+
+fn set_and_unlock(
+  conn: valkyrie.Connection,
+  key: String,
+  state: bucket.BucketState,
+  ttl: Int,
+) -> Result(Nil, Nil) {
+  let result = case
+    valkyrie.hset(
+      conn,
+      key,
+      bucket.to_pairs(state) |> dict.from_list,
+      default_timeout,
+    )
+  {
+    Ok(_) -> {
+      let _ = valkyrie.expire(conn, key, ttl, None, default_timeout)
+      Ok(Nil)
+    }
+    Error(_) -> Error(Nil)
+  }
+  let _ = unlock(conn, key)
+  result
+}
+
+pub fn new(conn: valkyrie.Connection) -> bucket.Store {
+  bucket.Store(
+    lock_and_get: fn(key) { lock_and_get(conn, key) },
+    set_and_unlock: fn(key, state, ttl) {
+      set_and_unlock(conn, key, state, ttl)
+    },
+    unlock: fn(key) { unlock(conn, key) },
+  )
+}


### PR DESCRIPTION
## Summary
- Extract Redis store backend from `app.gleam` into dedicated `redis_store.gleam` module with named functions
- Deduplicate `redis_timeout` constant into `redis_store.default_timeout`
- Extract `":lock"` suffix into `lock_key` helper

## Test plan
- [x] `gleam build` passes for redis example
- [x] `gleam test` passes for main project (67 tests)